### PR TITLE
Extracted database credentials to env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,8 +10,9 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
   timeout: 5000
-  username: postgres
-  password: 54321
+  username: <%= ENV['RECIPE_APP_DATABASE_USERNAME'] %>
+  password: <%= ENV['RECIPE_APP_DATABASE_PASSWORD'] %>
+
 
 development:
   <<: *default


### PR DESCRIPTION
Hi @Atril33

As discussed, I extracted the database credentials to environment variables. This will allow us to work on our own separate databases while using the same config file. If you are on Linux, here are the commands to set this up: 

`echo 'export RECIPE_APP_DATABASE_USERNAME="postgres"' >> ~/.bash_profile`
`echo 'export RECIPE_APP_DATABASE_PASSWORD="54321"' >> ~/.bash_profile`
`source ~/.bash_profile`